### PR TITLE
Introduce concurrent tasks scheduler package

### DIFF
--- a/example/tasks.go
+++ b/example/tasks.go
@@ -1,0 +1,32 @@
+package example
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+type Task struct {
+	Id int
+}
+
+func (t *Task) ID() int {
+	return t.Id
+}
+
+func (t *Task) Run(ctx context.Context) error {
+	time.Sleep(1 * time.Second) // simulate work
+	return nil
+}
+
+type ErrorTask struct {
+	Id int
+}
+
+func (t *ErrorTask) ID() int {
+	return t.Id
+}
+func (t *ErrorTask) Run(ctx context.Context) error {
+	time.Sleep(5 * time.Second) // simulate work
+	return fmt.Errorf("simulated error in task %d", t.Id)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module scheduler
+
+go 1.24
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"scheduler/example"
+	"scheduler/mocks"
+	scheduler "scheduler/task-scheduler"
+	"time"
+)
+
+func main() {
+	// Initialize the task scheduler
+	s := scheduler.NewScheduler()
+	s.SetMaxWorkers(40)
+
+	// Monitor ongoing tasks every 3 seconds
+	go s.SchedulerMonitor(3 * time.Second)
+
+	// Start the scheduler to process registered tasks
+	go s.RunScheduler()
+
+	// Register tasks with various decorators prior running the scheduler
+
+	// Default task with no decorators
+	s.RegisterTask(&example.Task{}, 100)
+	// Task with logging enabled
+	s.RegisterTask(&example.Task{}, 200, scheduler.WithLogging())
+	// Task with delay, name and logging enabled
+	s.RegisterTask(&example.Task{}, 300, scheduler.WithDelay(5*time.Second), scheduler.WithName("TAL-Task-3"), scheduler.WithLogging())
+	// Task with retry, delay, name and logging enabled
+	s.RegisterTask(&example.Task{}, 400, scheduler.WithRetry(2), scheduler.WithDelay(3*time.Second), scheduler.WithName("TAL-Task-4"), scheduler.WithLogging())
+	// Task that simulates an error
+	s.RegisterTask(&example.ErrorTask{}, 500, scheduler.WithRetry(3), scheduler.WithName("TAL-Error-Task"), scheduler.WithLogging())
+	// Task that simulates task success on the 3rd attempt
+	retryTask := mocks.NewRetryTestTask(600, "retryTask", 3, 2)
+	s.RegisterTask(retryTask, 600, scheduler.WithRetry(3), scheduler.WithLogging(), scheduler.WithName("retryTask"))
+
+	// Register a range of tasks with different configurations
+	for i := 0; i <= 99; i++ {
+		if i%10 == 0 { // Every 10th task has logging enabled
+			s.RegisterTask(&example.Task{}, i, scheduler.WithLogging(), scheduler.WithRetry(3))
+		} else {
+			s.RegisterTask(&example.Task{}, i, scheduler.WithRetry(3))
+
+		}
+	}
+
+	// Close the scheduler to stop accepting new tasks and wait for all tasks to finish
+	s.Stop()
+
+	s.SummaryReport()
+}

--- a/mocks/task.go
+++ b/mocks/task.go
@@ -1,0 +1,60 @@
+package mocks
+
+import (
+	"context"
+	"errors"
+	"log"
+	"sync/atomic"
+	"time"
+)
+
+// MockTask Mock task for testing
+type MockTask struct {
+	id            int
+	name          string
+	shouldFail    bool
+	executionTime time.Duration
+	executed      int32
+	logger        *log.Logger
+	runFunc       func(ctx context.Context) error
+}
+
+func (m *MockTask) Run(ctx context.Context) error {
+	atomic.AddInt32(&m.executed, 1)
+
+	if m.executionTime > 0 {
+		select {
+		case <-time.After(m.executionTime):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	if m.shouldFail {
+		return errors.New("mock task failed")
+	}
+	return nil
+}
+
+func NewMockTask(id int, name string) *MockTask {
+	return &MockTask{id: id, name: name}
+}
+
+func NewMockTimedTask(id int, name string, duration time.Duration) *MockTask {
+	return &MockTask{id: id, name: name, executionTime: duration}
+}
+
+func (m *MockTask) SetExecutionTime(executionTime time.Duration) *MockTask {
+	m.executionTime = executionTime
+	return m
+}
+
+func (m *MockTask) SetShouldFail(shouldFail bool) *MockTask {
+	m.shouldFail = shouldFail
+	return m
+}
+
+// ExecutionCount safely returns the number of times a mock task has been executed (i.e., how many times its Run() method was called), using atomic operations to avoid race conditions in concurrent tests.
+func (m *MockTask) ExecutionCount() int {
+	return int(atomic.LoadInt32(&m.executed))
+}

--- a/mocks/task.go
+++ b/mocks/task.go
@@ -3,20 +3,24 @@ package mocks
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
+	"os"
 	"sync/atomic"
 	"time"
 )
 
 // MockTask Mock task for testing
 type MockTask struct {
-	id            int
-	name          string
-	shouldFail    bool
-	executionTime time.Duration
-	executed      int32
-	logger        *log.Logger
-	runFunc       func(ctx context.Context) error
+	id              int
+	name            string
+	shouldFail      bool
+	executionTime   time.Duration
+	executed        int32
+	logger          *log.Logger
+	runFunc         func(ctx context.Context) error
+	failureCount    int   // How many times to fail before succeeding
+	currentAttempts int32 // Thread-safe attempt counter
 }
 
 func (m *MockTask) Run(ctx context.Context) error {
@@ -57,4 +61,48 @@ func (m *MockTask) SetShouldFail(shouldFail bool) *MockTask {
 // ExecutionCount safely returns the number of times a mock task has been executed (i.e., how many times its Run() method was called), using atomic operations to avoid race conditions in concurrent tests.
 func (m *MockTask) ExecutionCount() int {
 	return int(atomic.LoadInt32(&m.executed))
+}
+
+// Test helper: Mock task with configurable retry behavior
+type RetryTestTask struct {
+	id              int
+	name            string
+	NumOfRetries    int   // Number of retries to attempt on failure (default 1)
+	failureCount    int   // How many times to fail before succeeding (-1 = always fail)
+	currentAttempts int32 // Thread-safe attempt counter
+	logger          *log.Logger
+}
+
+func NewRetryTestTask(id int, name string, retries int, failuresBeforeSuccess int) *RetryTestTask {
+	return &RetryTestTask{
+		id:           id,
+		name:         name,
+		NumOfRetries: retries,
+		failureCount: failuresBeforeSuccess,
+		logger:       log.New(os.Stdout, fmt.Sprintf("[RetryTask-%s] ", name), log.LstdFlags),
+	}
+}
+
+func (r *RetryTestTask) Run(ctx context.Context) error {
+	attempt := atomic.AddInt32(&r.currentAttempts, 1)
+
+	// Simulate some work
+	time.Sleep(5 * time.Millisecond)
+
+	// Always fail if failureCount is -1
+	if r.failureCount == -1 {
+		return fmt.Errorf("task %d always fails (attempt %d)", r.id, attempt)
+	}
+
+	// Fail for the specified number of attempts, then succeed
+	if int(attempt) <= r.failureCount {
+		return fmt.Errorf("task %d failed on attempt %d", r.id, attempt)
+	}
+	r.logger.Printf("task %d succeeded on attempt %d", r.id, attempt)
+	// Success
+	return nil
+}
+
+func (r *RetryTestTask) GetAttemptCount() int {
+	return int(atomic.LoadInt32(&r.currentAttempts))
 }

--- a/task-scheduler/decorators.go
+++ b/task-scheduler/decorators.go
@@ -32,3 +32,14 @@ func WithDelay(delay time.Duration) TaskOption {
 		task.delay = delay
 	}
 }
+
+// WithRetry creates a task decorator that retries the task on failure.
+// It accepts a number of retries, which must be between 1 and 100.
+// If the number of retries is outside this range, it will not change the default value (1).
+func WithRetry(retries int) TaskOption {
+	return func(task *task) {
+		if 1 <= retries && retries <= 100 {
+			task.NumOfRetries = retries
+		}
+	}
+}

--- a/task-scheduler/decorators.go
+++ b/task-scheduler/decorators.go
@@ -1,0 +1,16 @@
+package task_scheduler
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+// WithLogging creates a task decorator that adds logging functionality.
+func WithLogging() TaskOption {
+	return func(task *task) {
+		if task.logger == nil {
+			task.logger = log.New(os.Stdout, fmt.Sprintf("task %d (%s): ", task.id, task.name), log.LstdFlags)
+		}
+	}
+}

--- a/task-scheduler/decorators.go
+++ b/task-scheduler/decorators.go
@@ -14,3 +14,13 @@ func WithLogging() TaskOption {
 		}
 	}
 }
+
+// WithName creates a task decorator that overrides the task's name.
+func WithName(name string) TaskOption {
+	return func(task *task) {
+		task.name = name
+		if task.logger != nil { // Update logger with name if it exists
+			task.logger = log.New(os.Stdout, fmt.Sprintf("task %d (%s): ", task.id, task.name), log.LstdFlags)
+		}
+	}
+}

--- a/task-scheduler/decorators.go
+++ b/task-scheduler/decorators.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 )
 
 // WithLogging creates a task decorator that adds logging functionality.
@@ -22,5 +23,12 @@ func WithName(name string) TaskOption {
 		if task.logger != nil { // Update logger with name if it exists
 			task.logger = log.New(os.Stdout, fmt.Sprintf("task %d (%s): ", task.id, task.name), log.LstdFlags)
 		}
+	}
+}
+
+// WithDelay creates a task decorator that delays execution by the specified duration.
+func WithDelay(delay time.Duration) TaskOption {
+	return func(task *task) {
+		task.delay = delay
 	}
 }

--- a/task-scheduler/delayDispatcher.go
+++ b/task-scheduler/delayDispatcher.go
@@ -1,0 +1,111 @@
+package task_scheduler
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Struct delayedTask couples a task with its desired execution time.
+type delayedTask struct {
+	task     task
+	execTime time.Time
+}
+
+// Struct delayDispatcher manages all delayed tasks in a single goroutine.
+// It accepts scheduling requests on delayedTaskChan and pushes tasks into the main scheduler taskChan once their execTime arrives.
+type delayDispatcher struct {
+	taskChan        chan<- task // Scheduler task channel
+	doneChan        chan struct{}
+	delayedTaskChan chan delayedTask
+	delayedCounter  *atomic.Int32 // Scheduler counter for currently delayed tasks
+	wg              sync.WaitGroup
+}
+
+// Call newDelayDispatcher launches the single dispatcher goroutine.
+func newDelayDispatcher(taskChan chan<- task, doneCh chan struct{}, currentDelayedTasks *atomic.Int32) *delayDispatcher {
+	d := &delayDispatcher{
+		taskChan:        taskChan,
+		delayedTaskChan: make(chan delayedTask),
+		delayedCounter:  currentDelayedTasks,
+		doneChan:        doneCh,
+	}
+	go d.run()
+	return d
+}
+
+// Call schedule enqueues task to be dispatched into delayedTaskChan
+func (d *delayDispatcher) schedule(t task, execTime time.Time) {
+	d.delayedTaskChan <- delayedTask{task: t, execTime: execTime}
+	d.wg.Add(1)
+}
+
+// Call run() launches the dispatcher event loop.
+// It maintains a time-ordered slice of pending scheduleRequests and uses one time.Timer to wait until the next execTime. When the timer fires, it drains all due tasks into taskChan.
+func (d *delayDispatcher) run() {
+	var queue []delayedTask      // Slice of pending delayed tasks, sorted by execTime
+	var timer *time.Timer        // Timer to wait for the next task execution
+	var timerCh <-chan time.Time // Channel to receive timer events
+
+	for {
+		// Timer management - if we have at least one pending request, (re)arm the timer for the soonest execTime
+		if len(queue) > 0 {
+			next := queue[0].execTime // The next execution time is the first in the queue
+			wait := time.Until(next)  // Calculate how long to wait until the next task should be executed
+			if timer == nil {
+				timer = time.NewTimer(maxDuration(wait)) // Create a new timer if it doesn't exist
+			} else {
+				timer.Reset(maxDuration(wait)) // Reset the existing timer to the new wait duration
+			}
+			timerCh = timer.C
+		} else if timer != nil {
+			timer.Stop()  // Stop the timer if there are no pending requests
+			timer = nil   // Reset the timer
+			timerCh = nil // Reset the timer channel
+		}
+
+		select {
+		case req := <-d.delayedTaskChan: // A new delayed task arrives
+			// Insert new delayed task in sorted order
+			queue = delayedTaskInsert(queue, req)
+
+		case now := <-timerCh:
+			// Dispatch all tasks whose time ≤ now
+			for len(queue) > 0 && !queue[0].execTime.After(now) {
+				d.taskChan <- queue[0].task // Send the task to the scheduler's task channel
+				d.wg.Done()                 // Decrement the wait group for the delayed tasks dispatcher
+				d.delayedCounter.Add(-1)    // Decrement the delayed tasks counter
+				queue = queue[1:]           // Remove the first task from the queue
+			}
+
+		case <-d.doneChan: // Scheduler is closing, close dispatcher gracefully
+			if timer != nil {
+				timer.Stop() // Stop the timer if it exists
+				break
+			}
+		}
+	}
+}
+
+// The maxDuration guards against negative durations.
+func maxDuration(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	return d
+}
+
+// Insert new delayed task in sorted order
+func delayedTaskInsert(queue []delayedTask, req delayedTask) []delayedTask {
+	i := len(queue)
+	for j, existing := range queue {
+		if req.execTime.Before(existing.execTime) { // Find the first task with execTime after the new task's execTime
+			i = j
+			break
+		}
+	}
+	queue = append(queue, delayedTask{}) // Make space
+	copy(queue[i+1:], queue[i:])         // Shift elements to the right
+	queue[i] = req                       // Insert the new task
+	return queue
+}

--- a/task-scheduler/delayDispatcher_test.go
+++ b/task-scheduler/delayDispatcher_test.go
@@ -1,0 +1,69 @@
+package task_scheduler
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestSingleDelayedTask tests that a single delayed task is executed after its scheduled time.
+// It ensures that the task is not executed before the delay and that the counter is decremented correctly.
+func TestSingleDelayedTask(t *testing.T) {
+	taskChan := make(chan task, 1)
+	doneChan := make(chan struct{})
+	counter := atomic.Int32{}
+	counter.Store(1) // Total number of tasks to be scheduled
+
+	dispatcher := newDelayDispatcher(taskChan, doneChan, &counter)
+	now := time.Now()
+	dispatcher.schedule(task{id: 1}, now.Add(100*time.Millisecond)) // Schedule a task with a 100ms delay
+
+	select {
+	case <-taskChan: // Task should not be received yet
+		t.Fatal("Task received too early")
+	case <-time.After(80 * time.Millisecond):
+		// OK: task not sent yet
+	}
+
+	select {
+	case tsk := <-taskChan: // Task should be received after the delay
+		assert.Equal(t, 0, int(counter.Load())) // Counter should be decremented to 0 after the task is sent
+		assert.Equal(t, 1, tsk.id)              // Check that the task ID is correct
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Task not received in time")
+	}
+}
+
+// TestMultipleDelayedTasksOrder tests that multiple delayed task are executed in the correct order based on their execution time.
+// It ensures that task with shorter delays are executed before those with longer delays.
+// It uses a buffered channel to hold all task and checks the order of their IDs.
+func TestMultipleDelayedTasksOrder(t *testing.T) {
+	taskChan := make(chan task, 3) // Buffer size of 3 to hold all tasks
+	doneChan := make(chan struct{})
+	counter := atomic.Int32{}
+	counter.Store(3) // Total number of tasks to be scheduled
+
+	dispatcher := newDelayDispatcher(taskChan, doneChan, &counter)
+
+	now := time.Now()
+	dispatcher.schedule(task{id: 1}, now.Add(120*time.Millisecond)) // This task has the longest delay
+	dispatcher.schedule(task{id: 2}, now.Add(50*time.Millisecond))  // This task has a medium delay
+	dispatcher.schedule(task{id: 3}, now.Add(90*time.Millisecond))  // This task has the shortest delay
+
+	var ids []int
+	timeout := time.After(1 * time.Second) // Set a timeout to avoid deadlock in case of issues
+	for len(ids) < 3 {                     // Loop to receive tasks from the channel
+		select {
+		case tsk := <-taskChan: // Received task from the channel
+			ids = append(ids, tsk.id) // Collect task ID
+			if len(ids) == 3 {
+				break // Exit the loop when all tasks are received
+			}
+		case <-timeout:
+			t.Fatal("Timeout waiting for tasks")
+		}
+	}
+
+	assert.Equal(t, []int{2, 3, 1}, ids, "Tasks should arrive in execTime order")
+}

--- a/task-scheduler/scheduler.go
+++ b/task-scheduler/scheduler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -176,5 +177,21 @@ func (s *Scheduler) SetMaxWorkers(maxWorkers int) {
 	} else {
 		s.maxWorkers = maxWorkers
 		log.Printf("✅ Using configured maxWorkers: %d", s.maxWorkers)
+	}
+}
+
+// SchedulerMonitor prints the current status of the Scheduler at client defined intervals (d).
+// It displays the number of ongoing, registered, delayed, finished, and failed tasks, as well as the number of goroutines currently running.
+func (s *Scheduler) SchedulerMonitor(d time.Duration) {
+	const (
+		Cyan  = "\033[36m" // ANSI escape code for cyan color
+		Reset = "\033[0m"  // ANSI escape code to reset color
+	)
+	for {
+		fmt.Printf(
+			Cyan+"🌀 Ongoing: %d | Registered: %d | Delayed: %d | Finished: %d | Failed: %d | Goroutines: %d\n"+Reset,
+			s.ongoingTasks.Load(), s.registeredTasks.Load(), s.currentDelayedTasks.Load(), s.finishedTasks.Load(), s.failedTasks.Load(), runtime.NumGoroutine(),
+		)
+		time.Sleep(d)
 	}
 }

--- a/task-scheduler/scheduler.go
+++ b/task-scheduler/scheduler.go
@@ -1,0 +1,55 @@
+package task_scheduler
+
+import (
+	"context"
+)
+
+const tasksBufferSize = 100 // Size of the task channel buffer
+
+// The RegisterableTask represents a unit of work that can be scheduled and executed.
+type RegisterableTask interface {
+	Run(ctx context.Context) error
+}
+
+// The task is the unexported implementation of the RegisterableTask interface, allowing additional metadata id and name to be wrapped around an inner RegisterableTask.
+type task struct {
+	id    int              // Unique identifier for the task
+	name  string           // Human-readable name
+	inner RegisterableTask // Wrapped RegisterableTask that provides the actual Run logic
+}
+
+// Run executes the inner RegisterableTask's Run method.
+func (t *task) Run(ctx context.Context) error {
+	return t.inner.Run(ctx)
+}
+
+// TaskOption is a decorator function that wraps a task, adding or modifying behavior such as retries, delays, or logging.
+// It takes an existing RegisterableTask and returns a new, decorated RegisterableTask.
+type TaskOption func(*task)
+
+// RegisterTask submits a Task for execution.
+func (s *Scheduler) RegisterTask(t RegisterableTask, opts ...TaskOption) {}
+
+// Scheduler manages task execution with controlled concurrency.
+type Scheduler struct {
+	taskChan chan task     // Channel for tasks to be executed
+	doneChan chan struct{} // Channel to signal completion of all tasks
+}
+
+// NewScheduler creates a new Scheduler instance.
+// It initializes the task channel and done channel, and sets the maximum number of concurrent workers.
+func NewScheduler() *Scheduler {
+	return &Scheduler{
+		taskChan: make(chan task, tasksBufferSize),
+		doneChan: make(chan struct{}),
+	}
+}
+
+// RunScheduler starts the main scheduling loop.
+func (s *Scheduler) RunScheduler() {}
+
+// Stop signals that no more tasks will be registered and waits for all tasks to finish.
+// Call this *after* all RegisterTask(...) calls.
+// Calling Stop() should be done after client has finished registering all tasks, so that the scheduler can process all tasks before closing the task channel.
+func (s *Scheduler) Stop() {
+}

--- a/task-scheduler/scheduler.go
+++ b/task-scheduler/scheduler.go
@@ -195,3 +195,18 @@ func (s *Scheduler) SchedulerMonitor(d time.Duration) {
 		time.Sleep(d)
 	}
 }
+
+// SummaryReport prints a final tally of tasks.
+// Calling SummaryReport should be after Stop() called, to ensure all tasks have been processed.
+// It provides a summary of the total registered, succeeded, and failed tasks.
+func (s *Scheduler) SummaryReport() {
+	fmt.Println("\n📊 Scheduler Summary Report:")
+	fmt.Printf("Total registered: %d\n", s.registeredTasks.Load())
+	fmt.Printf("Total succeeded:  %d\n", s.finishedTasks.Load())
+	fmt.Printf("Total failed:     %d\n", s.failedTasks.Load())
+	if s.registeredTasks.Load() == s.finishedTasks.Load() {
+		fmt.Println("✅ All tasks completed successfully!")
+	} else {
+		fmt.Println("⚠️ Some tasks did not finish successfully.")
+	}
+}

--- a/task-scheduler/scheduler_test.go
+++ b/task-scheduler/scheduler_test.go
@@ -1,0 +1,117 @@
+package task_scheduler
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"scheduler/mocks"
+	"testing"
+	"time"
+)
+
+func TestScheduler_RunScheduler(t *testing.T) {
+	tests := []struct {
+		name                string
+		tasks               []RegisterableTask
+		expectedFinished    int
+		expectedFailed      int
+		checkConcurrency    bool
+		maxExpectedDuration time.Duration
+		testTimeout         time.Duration
+	}{
+		{
+			name:             "successful tasks",
+			tasks:            []RegisterableTask{mocks.NewMockTask(1, "task-1"), mocks.NewMockTask(2, "task-2")},
+			expectedFinished: 2,
+			expectedFailed:   0,
+		},
+		{
+			name:             "tasks with failures",
+			tasks:            []RegisterableTask{mocks.NewMockTask(1, "task-1"), mocks.NewMockTask(2, "task-2").SetShouldFail(true)},
+			expectedFinished: 1,
+			expectedFailed:   1,
+		},
+		{
+			name:                "concurrent execution",
+			tasks:               createMultipleTimedTasks(10, 50*time.Millisecond),
+			expectedFinished:    10,
+			expectedFailed:      0,
+			checkConcurrency:    true,
+			maxExpectedDuration: 100 * time.Millisecond, // Sufficient time to process 10 tasks with 50 ms each with default 50 workers concurrently
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewScheduler()
+			// Register tasks
+			for i, task := range tt.tasks {
+				s.RegisterTask(task, i)
+			}
+
+			start := time.Now()
+
+			go s.RunScheduler()
+			// Wait for tasks to finish
+			s.Stop()
+
+			duration := time.Since(start)
+
+			// Check results
+			assert.Equal(t, tt.expectedFinished, int(s.finishedTasks.Load()))
+			assert.Equal(t, tt.expectedFailed, int(s.failedTasks.Load()))
+
+			if tt.checkConcurrency {
+				assert.Less(t, duration, tt.maxExpectedDuration, "Tasks should execute concurrently")
+			}
+		})
+	}
+}
+
+// Helper function to create mock tasks with a fixed execution time
+func createMultipleTimedTasks(count int, duration time.Duration) []RegisterableTask {
+	tasks := make([]RegisterableTask, count)
+	for i := 0; i < count; i++ {
+		tasks[i] = mocks.NewMockTimedTask(i, fmt.Sprintf("task-%d", i), duration)
+	}
+	return tasks
+}
+
+func TestScheduler_RegisterTask(t *testing.T) {
+	tests := []struct {
+		name                    string
+		tasks                   []RegisterableTask
+		options                 [][]TaskOption
+		expectedRegisteredTasks int32
+	}{
+		{
+			name:                    "register single task",
+			tasks:                   []RegisterableTask{mocks.NewMockTask(1, "test-task")},
+			options:                 [][]TaskOption{},
+			expectedRegisteredTasks: 1,
+		},
+		{
+			name: "register multiple tasks",
+			tasks: []RegisterableTask{
+				mocks.NewMockTask(1, "task-1"),
+				mocks.NewMockTask(2, "task-2"),
+				mocks.NewMockTask(3, "task-3"),
+			},
+			expectedRegisteredTasks: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewScheduler()
+
+			for i, task := range tt.tasks {
+				if len(tt.options) > 0 {
+					s.RegisterTask(task, i, tt.options[i]...)
+				} else {
+					s.RegisterTask(task, i)
+				}
+			}
+			assert.Equal(t, tt.expectedRegisteredTasks, s.registeredTasks.Load())
+		})
+	}
+}


### PR DESCRIPTION
## **🚀 First Pull Request at OneLayer!**

This pull request is my first at OneLayer! 🎉

## **Overview**

This PR introduces a comprehensive **scheduler package** that enables concurrent task execution with advanced control features. 
The package provides a robust foundation for running tasks concurrently while maintaining visibility into their execution status.

## **Key Features**

### **Core Scheduler**

- **Concurrent Execution**: Configurable worker pool with controllable concurrency limits
- **Task Registration**: Simple interface for registering tasks with optional decorators
- **Real-time Monitoring**: Live tracking of ongoing, finished, and failed tasks
- **Comprehensive Reporting**: Detailed summary reports with success/failure statistics

### **Task Decorators (Higher-Order Functions)**

The package implements a flexible decorator pattern allowing tasks to be enhanced with additional capabilities:

- **`WithName`**: Assigns custom names to tasks for better identification
- **`WithLogging`**: Adds detailed execution logging
- **`WithRetry`**: Implements automatic retry logic with configurable retry counts
- **`WithDelay`**: Adds scheduled delays before task execution

### **Task Interface**

Clean, simple interface that any task can implement:

```go
type RegisterableTask interface {
    Run(ctx context.Context) error
}
```

## **Architecture Highlights**

- **Worker Pool Pattern**: Efficient concurrent execution with configurable max workers
- **Graceful Shutdown**: Proper cleanup and completion tracking

## **Usage Example**

```go
scheduler := NewScheduler()
scheduler.SetMaxWorkers(10)

// Register tasks with decorators
scheduler.RegisterTask(yourTask,  
    1,  // task-id
    WithName("your-task-name"),            
    WithRetry(3),
    WithLogging(),
    WithDelay(5*time.Second),
)


go scheduler.RunScheduler() // execute all tasks

scheduler.Stop()   // stop accepting new tasks and wait for all registered tasks to finish 

scheduler.SummaryReport()
```

Proof: https://github.com/talhadar1/scheduler/pull/1#issuecomment-3004647682